### PR TITLE
Adhere to cocoapods 1.5 convention

### DIFF
--- a/CountryPickerSwift.podspec
+++ b/CountryPickerSwift.podspec
@@ -28,10 +28,9 @@ TODO: CountryCode Picker
   s.social_media_url = 'https://twitter.com/lulz_ua'
   s.ios.deployment_target = '8.0'
   s.module_name  = 'CountryPicker'
-  s.source_files = 'CountryPicker/Classes/*'
-  s.resources = 'CountryPicker/Classes/CountryView.xib'
+  s.source_files = 'CountryPicker/Classes/*.{swift}'
   s.resource_bundles = {
-    'CountryPicker' => ['CountryPicker/Assets/CountryPicker.bundle/*']
+    'CountryPicker' => ['CountryPicker/Assets/CountryPicker.bundle/*', 'CountryPicker/Classes/CountryView.xib', 'CountryPicker/Classes/Flags.xcassets']
   }
 
   #s.dependency 'libPhoneNumber-iOS', '~> 0.8'

--- a/CountryPickerSwift.podspec
+++ b/CountryPickerSwift.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'CountryPickerSwift'
-  s.version          = '1.7.1'
+  s.version          = '1.7.2'
   s.summary          = 'Swift CountryPicker'
 
 # This description is used to generate tags and improve search results.

--- a/CountryPickerSwift.podspec
+++ b/CountryPickerSwift.podspec
@@ -29,8 +29,9 @@ TODO: CountryCode Picker
   s.ios.deployment_target = '8.0'
   s.module_name  = 'CountryPicker'
   s.source_files = 'CountryPicker/Classes/*'
+  s.resources = 'CountryPicker/Classes/CountryView.xib'
   s.resource_bundles = {
-    'CountryPicker' => ['CountryPicker/Assets/CountryPicker.bundle/*', 'CountryPicker/Classes/CountryView.xib']
+    'CountryPicker' => ['CountryPicker/Assets/CountryPicker.bundle/*']
   }
 
   #s.dependency 'libPhoneNumber-iOS', '~> 0.8'

--- a/CountryPickerSwift.podspec
+++ b/CountryPickerSwift.podspec
@@ -30,7 +30,7 @@ TODO: CountryCode Picker
   s.module_name  = 'CountryPicker'
   s.source_files = 'CountryPicker/Classes/*'
   s.resource_bundles = {
-    'CountryPicker' => ['CountryPicker/Assets/CountryPicker.bundle/*']
+    'CountryPicker' => ['CountryPicker/Assets/CountryPicker.bundle/*', 'CountryPicker/Classes/CountryView.xib']
   }
 
   #s.dependency 'libPhoneNumber-iOS', '~> 0.8'


### PR DESCRIPTION
- Version bump
- Moved nib files to resources instead of source files in podspec.
- Works without `use frameworks!` flag in Podfile.