### PR TITLE
Crash while building release version #41

### DIFF
--- a/CountryPickerSwift.podspec
+++ b/CountryPickerSwift.podspec
@@ -30,9 +30,7 @@ TODO: CountryCode Picker
   s.ios.deployment_target = '8.0'
   s.module_name  = 'CountryPicker'
   s.source_files = 'CountryPicker/Classes/*.{swift}'
-  s.resource_bundles = {
-    'CountryPicker' => ['CountryPicker/Assets/CountryPicker.bundle/*', 'CountryPicker/Classes/CountryView.xib', 'CountryPicker/Classes/Flags.xcassets']
-  }
+  s.resources = 'CountryPicker/**/*.{xib,bundle,xcassets}'
 
   #s.dependency 'libPhoneNumber-iOS', '~> 0.8'
 

--- a/Example/CountryPicker.xcodeproj/xcshareddata/xcschemes/CountryPicker-Example.xcscheme
+++ b/Example/CountryPicker.xcodeproj/xcshareddata/xcschemes/CountryPicker-Example.xcscheme
@@ -40,9 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -75,7 +74,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - CountryPickerSwift (1.7.1)
+  - CountryPickerSwift (1.7.3)
 
 DEPENDENCIES:
   - CountryPickerSwift (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  CountryPickerSwift: dd8bd27cfaa53985d67851c8d5d48c757c5a5303
+  CountryPickerSwift: c2ea9229e80b3717d5f4d47ca22a27f90c760751
 
 PODFILE CHECKSUM: 8ce74047b5fc00e1746f5c660212d2e58313970a
 

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - CountryPickerSwift (1.7.1)
+  - CountryPickerSwift (1.7.3)
 
 DEPENDENCIES:
   - CountryPickerSwift (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  CountryPickerSwift: dd8bd27cfaa53985d67851c8d5d48c757c5a5303
+  CountryPickerSwift: c2ea9229e80b3717d5f4d47ca22a27f90c760751
 
 PODFILE CHECKSUM: 8ce74047b5fc00e1746f5c660212d2e58313970a
 

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,22 +7,21 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		11D530460099E05EBB52E562C58FF4BF /* CountryViewTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F688021DAA3A95164D04D8B559EB90D /* CountryViewTheme.swift */; };
 		18696B6025609D6AA1549E04607DC1FB /* Pods-CountryPicker_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 023289D63DDB9E93325EEE4EE6316664 /* Pods-CountryPicker_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1ECFB95D5027B0E84048DDCA1C8560C4 /* CountryView.xib in Sources */ = {isa = PBXBuildFile; fileRef = B4D2897D58EA8670B60762416F32952D /* CountryView.xib */; };
-		4119FC15F9A7CFBCB5CEC272FED85BB3 /* Data in Resources */ = {isa = PBXBuildFile; fileRef = 025CAA8613B90D29DBAFCCC9D58A4509 /* Data */; };
-		4479F083EF7BAA3900A6B4FDB44FF898 /* CountryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A125E645B51CAD1818FDBE7C26B0D4F /* CountryView.swift */; };
-		50678BF1924742865714B066346FB28E /* CountryPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3394D5A8D8BE81B2FC3BBB5C356656C6 /* CountryPicker.swift */; };
-		513FA0C9E3F7BD3F5B645688A7C64ADD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A16F4CFC63FAC439D7A04994F579A03 /* Foundation.framework */; };
-		647B455655DD44E4BF59CE393B70EB14 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A16F4CFC63FAC439D7A04994F579A03 /* Foundation.framework */; };
-		93BE6DB84957C3BD2C683768FEDEFA79 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A16F4CFC63FAC439D7A04994F579A03 /* Foundation.framework */; };
+		1B9190EFB9A49D21D50B00BA7295D8EC /* CountryPickerSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 809AC8DECC19B9758B6ED5684E94C7A3 /* CountryPickerSwift-dummy.m */; };
+		35D0A2B7618A6A68403F0DD75274DA7A /* Flags.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0445C926242CF429A9C4EAD8D4749729 /* Flags.xcassets */; };
+		3ED872F46B1A827F723136A96A953BDC /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6604A7D69453B4569E4E4827FB9155A9 /* Foundation.framework */; };
+		4BA23FB270493ADBD85CD7C568F6C686 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6604A7D69453B4569E4E4827FB9155A9 /* Foundation.framework */; };
+		4BBD98A04F28E972987EAFCCDC42623F /* CountryView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9AA84FE8C9AFC29B0FC4647BA492C4F3 /* CountryView.xib */; };
+		78FA7604C2CC8B0E7F0ABD6162DCC0E5 /* CountryPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F57299B8A4404FF21CDA426BC0C07B /* CountryPicker.swift */; };
+		86F0BCCFA7F2BB948998BCAF121D1DCF /* CountryPickerSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = FA2154BC506C6D6BE0A885204DBDAA7C /* CountryPickerSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9460E06B3C5C0101634598F4E0444CDC /* Pods-CountryPicker_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B731F4709CB212067ED08CBDF2501DC /* Pods-CountryPicker_Example-dummy.m */; };
+		9EBFED3003641697F06F0C6432AB0859 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6604A7D69453B4569E4E4827FB9155A9 /* Foundation.framework */; };
 		BA446442707BB4AD8ACEECB5A7FD6BEC /* Pods-CountryPicker_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 6766BA4FAD9CC09F0855032CF67493D0 /* Pods-CountryPicker_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C033B8CB562EFBDCF5C566483FD58212 /* CountryPicker.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 293B35B9C2FFAEF6FAB48F03110BEC40 /* CountryPicker.bundle */; };
-		C52629C606D3851B56831DC762B2C4BC /* CountryPickerSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DCBA1A6ED0478E765C7F5FCAF778EF6F /* CountryPickerSwift-dummy.m */; };
+		BA9BB2689D1F7EFB53EF442AFC4B82E8 /* CountryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEDD87DF6B2E008708DC00FCA76B1575 /* CountryView.swift */; };
+		BEC0FC600B709FDBAA3D5EC5EF62C71A /* CountryPicker.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 7ED665EC6148284D074D91BD2D568507 /* CountryPicker.bundle */; };
 		CF1CCF6FF9CD41231304CB60D3FB11E3 /* Pods-CountryPicker_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C73BCD8733AD44383E52BC1AE5BEBF94 /* Pods-CountryPicker_Tests-dummy.m */; };
-		EF9514F76AE749515D36F6FE4AAA1F48 /* CountryPickerSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 28011D46262278D6737BECDE44643F0B /* CountryPickerSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F7F24D365351F0ADBA12D4DE1A46D986 /* Images in Resources */ = {isa = PBXBuildFile; fileRef = 3BBF93F18E97641B3EF7ED5AD50202DC /* Images */; };
+		F67EDB02D7738D3E92CDEDAC743F1DD3 /* CountryViewTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55F9800B76E6BA34761F6BA26D69DFF /* CountryViewTheme.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -30,7 +29,7 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 15AF30C8115A773B14C33A1C97C018E5;
+			remoteGlobalIDString = F4B55C5FBC8AD531B30BE59C71695A0D;
 			remoteInfo = CountryPickerSwift;
 		};
 		5F547B3B853B20EE18C453E7AA7565D2 /* PBXContainerItemProxy */ = {
@@ -40,73 +39,57 @@
 			remoteGlobalIDString = 3ED74298185CE2A6AB9074E6815A9A38;
 			remoteInfo = "Pods-CountryPicker_Example";
 		};
-		C867ABF451C723BFC1EC672CB703CD92 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 1D60595B83998629E5BF7286F76298D0;
-			remoteInfo = "CountryPickerSwift-CountryPicker";
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		023289D63DDB9E93325EEE4EE6316664 /* Pods-CountryPicker_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-CountryPicker_Example-umbrella.h"; sourceTree = "<group>"; };
-		025CAA8613B90D29DBAFCCC9D58A4509 /* Data */ = {isa = PBXFileReference; includeInIndex = 1; name = Data; path = CountryPicker/Assets/CountryPicker.bundle/Data; sourceTree = "<group>"; };
+		0445C926242CF429A9C4EAD8D4749729 /* Flags.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = Flags.xcassets; sourceTree = "<group>"; };
 		04F1D23BC15ECCDD68B2181B93A9CE27 /* Pods-CountryPicker_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-CountryPicker_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		0B731F4709CB212067ED08CBDF2501DC /* Pods-CountryPicker_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-CountryPicker_Example-dummy.m"; sourceTree = "<group>"; };
+		0BB001A7F239D548C6256ABB43A531F0 /* Pods_CountryPicker_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_CountryPicker_Example.framework; path = "Pods-CountryPicker_Example.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		13014C828FE6C001D5B4857E213979DF /* CountryPicker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = CountryPicker.framework; path = CountryPickerSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1B22A0C25E3D6C54656096673881FF24 /* Pods-CountryPicker_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-CountryPicker_Example.release.xcconfig"; sourceTree = "<group>"; };
-		1BA4A49C63967AD6B861C29F09758C1B /* Pods_CountryPicker_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_CountryPicker_Example.framework; path = "Pods-CountryPicker_Example.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1DFC453C7245D384D03F0635FFBA1E3D /* Pods_CountryPicker_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_CountryPicker_Tests.framework; path = "Pods-CountryPicker_Tests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1E887D1E2A005BCDA387BDE52C9BD183 /* Pods-CountryPicker_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-CountryPicker_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		24A2A13A9371F549A5ED76406E330691 /* Pods-CountryPicker_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-CountryPicker_Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		28011D46262278D6737BECDE44643F0B /* CountryPickerSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CountryPickerSwift-umbrella.h"; sourceTree = "<group>"; };
-		291482A4DA68041C2FBC8288A895D7E2 /* CountryPicker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = CountryPicker.framework; path = CountryPickerSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		293B35B9C2FFAEF6FAB48F03110BEC40 /* CountryPicker.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = CountryPicker.bundle; path = "CountryPickerSwift-CountryPicker.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
-		2A125E645B51CAD1818FDBE7C26B0D4F /* CountryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CountryView.swift; path = CountryPicker/Classes/CountryView.swift; sourceTree = "<group>"; };
-		3394D5A8D8BE81B2FC3BBB5C356656C6 /* CountryPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CountryPicker.swift; path = CountryPicker/Classes/CountryPicker.swift; sourceTree = "<group>"; };
-		370CFCD40AD7C7F089B48A99A9866301 /* CountryPickerSwift.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; path = CountryPickerSwift.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		3BBF93F18E97641B3EF7ED5AD50202DC /* Images */ = {isa = PBXFileReference; includeInIndex = 1; name = Images; path = CountryPicker/Assets/CountryPicker.bundle/Images; sourceTree = "<group>"; };
+		36809505866F9F83FB9FFE2284EA89A9 /* CountryPickerSwift.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; path = CountryPickerSwift.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		3C7D60458641B64850F0932E910DABFE /* Pods-CountryPicker_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-CountryPicker_Tests-frameworks.sh"; sourceTree = "<group>"; };
+		3D4E3A05C19DA3101217F2C7EECB5003 /* CountryPickerSwift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CountryPickerSwift.xcconfig; sourceTree = "<group>"; };
+		4BA7525F315A842F97E1DC39C9E67C65 /* CountryPickerSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CountryPickerSwift-prefix.pch"; sourceTree = "<group>"; };
 		4CAFECED889F9FA7D2DC1DC61C3B2F58 /* Pods-CountryPicker_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-CountryPicker_Tests.modulemap"; sourceTree = "<group>"; };
-		4F688021DAA3A95164D04D8B559EB90D /* CountryViewTheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CountryViewTheme.swift; path = CountryPicker/Classes/CountryViewTheme.swift; sourceTree = "<group>"; };
-		514A047EFD69C077B3F0215CACEC531F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		5A16F4CFC63FAC439D7A04994F579A03 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		5DA93D91C282ACE37A0836C307F35BFB /* CountryPickerSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CountryPickerSwift-prefix.pch"; sourceTree = "<group>"; };
+		54348BC98699843A76E5FCCC9916E2D1 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		6604A7D69453B4569E4E4827FB9155A9 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		6766BA4FAD9CC09F0855032CF67493D0 /* Pods-CountryPicker_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-CountryPicker_Tests-umbrella.h"; sourceTree = "<group>"; };
-		6B0B4373D8A17E3CF8CCA4A47AD22455 /* ResourceBundle-CountryPicker-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ResourceBundle-CountryPicker-Info.plist"; sourceTree = "<group>"; };
-		70240CDDF836F7AC9DB70DB5BA30F85A /* Pods_CountryPicker_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_CountryPicker_Tests.framework; path = "Pods-CountryPicker_Tests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		67F57299B8A4404FF21CDA426BC0C07B /* CountryPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CountryPicker.swift; path = CountryPicker/Classes/CountryPicker.swift; sourceTree = "<group>"; };
+		6C5555CC500AB7A68F54135A9B6BACE7 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		73B4B6FF5036FADC7EA762662E33FEF7 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		7E3B6B663AB6FE45D742C22C37FACCE1 /* CountryPickerSwift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CountryPickerSwift.xcconfig; sourceTree = "<group>"; };
-		826DCF5F725D40932618C2B19C3119C0 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
+		7ED665EC6148284D074D91BD2D568507 /* CountryPicker.bundle */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "wrapper.plug-in"; path = CountryPicker.bundle; sourceTree = "<group>"; };
+		809AC8DECC19B9758B6ED5684E94C7A3 /* CountryPickerSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CountryPickerSwift-dummy.m"; sourceTree = "<group>"; };
 		8F167F116C4E67E3A9378765183A9ED9 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8F5C05F17B7C9E9C60C71B2566B758B9 /* Pods-CountryPicker_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-CountryPicker_Example-frameworks.sh"; sourceTree = "<group>"; };
 		8FE44EFA37DEC504C25B4AC27F89DFDC /* Pods-CountryPicker_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-CountryPicker_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
 		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		95BB22D37F53065514C488373FF029F5 /* Pods-CountryPicker_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-CountryPicker_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
+		9AA84FE8C9AFC29B0FC4647BA492C4F3 /* CountryView.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = CountryView.xib; sourceTree = "<group>"; };
 		9C6BE659930DC4D3DB93BA62C991656A /* Pods-CountryPicker_Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-CountryPicker_Tests-resources.sh"; sourceTree = "<group>"; };
+		AEDD87DF6B2E008708DC00FCA76B1575 /* CountryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CountryView.swift; path = CountryPicker/Classes/CountryView.swift; sourceTree = "<group>"; };
 		B03BF9737EA0E9C814F47E3B3C54DB9A /* Pods-CountryPicker_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-CountryPicker_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		B0B1BB7B4304943A224BBB78B3B2A138 /* Pods-CountryPicker_Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-CountryPicker_Example-resources.sh"; sourceTree = "<group>"; };
-		B4D2897D58EA8670B60762416F32952D /* CountryView.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; name = CountryView.xib; path = CountryPicker/Classes/CountryView.xib; sourceTree = "<group>"; };
 		BE6CAE8B6CFC2204EF21BF60D3BFAA5F /* Pods-CountryPicker_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-CountryPicker_Example-acknowledgements.plist"; sourceTree = "<group>"; };
+		C54CBAE888CEC4F59EF391CFABF093FB /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
 		C73BCD8733AD44383E52BC1AE5BEBF94 /* Pods-CountryPicker_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-CountryPicker_Tests-dummy.m"; sourceTree = "<group>"; };
-		D5EC8D60BA32B3018A381C8202DE0D17 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
-		DCBA1A6ED0478E765C7F5FCAF778EF6F /* CountryPickerSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CountryPickerSwift-dummy.m"; sourceTree = "<group>"; };
-		E3A66D85DB3F80908BACB965E5039416 /* CountryPickerSwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CountryPickerSwift.modulemap; sourceTree = "<group>"; };
+		E55F9800B76E6BA34761F6BA26D69DFF /* CountryViewTheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CountryViewTheme.swift; path = CountryPicker/Classes/CountryViewTheme.swift; sourceTree = "<group>"; };
+		F14AE853B227D6C36EB8B74F7290493F /* CountryPickerSwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CountryPickerSwift.modulemap; sourceTree = "<group>"; };
+		FA2154BC506C6D6BE0A885204DBDAA7C /* CountryPickerSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CountryPickerSwift-umbrella.h"; sourceTree = "<group>"; };
 		FA967E6D9A60A61D99378AB75B6394A6 /* Pods-CountryPicker_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-CountryPicker_Example.modulemap"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		2D0A5AD998F86F35D22EC640C5DA0852 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		4B69E22491FE618DD220EFA8F4E583D2 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				647B455655DD44E4BF59CE393B70EB14 /* Foundation.framework in Frameworks */,
+				9EBFED3003641697F06F0C6432AB0859 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -114,15 +97,15 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				513FA0C9E3F7BD3F5B645688A7C64ADD /* Foundation.framework in Frameworks */,
+				3ED872F46B1A827F723136A96A953BDC /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A413592AE2F85D9CA4B7FEA2000591EE /* Frameworks */ = {
+		7D05270AFC7099DCCF83AB45485844A4 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				93BE6DB84957C3BD2C683768FEDEFA79 /* Foundation.framework in Frameworks */,
+				4BA23FB270493ADBD85CD7C568F6C686 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -147,70 +130,46 @@
 			path = "Target Support Files/Pods-CountryPicker_Example";
 			sourceTree = "<group>";
 		};
-		477B19B23BBFF464D0682C4E746B9F4E /* CountryPickerSwift */ = {
+		541F7E9C90D2A369B4782343F9000FB9 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				3394D5A8D8BE81B2FC3BBB5C356656C6 /* CountryPicker.swift */,
-				2A125E645B51CAD1818FDBE7C26B0D4F /* CountryView.swift */,
-				B4D2897D58EA8670B60762416F32952D /* CountryView.xib */,
-				4F688021DAA3A95164D04D8B559EB90D /* CountryViewTheme.swift */,
-				7C0B782E81357EEA3BC977143699D919 /* Pod */,
-				58ACF619266A53209409002839B1B079 /* Resources */,
-				7939F254B0573A96D21B881CD2029C08 /* Support Files */,
-			);
-			name = CountryPickerSwift;
-			path = ../..;
-			sourceTree = "<group>";
-		};
-		58ACF619266A53209409002839B1B079 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				025CAA8613B90D29DBAFCCC9D58A4509 /* Data */,
-				3BBF93F18E97641B3EF7ED5AD50202DC /* Images */,
-			);
-			name = Resources;
-			sourceTree = "<group>";
-		};
-		5E0D919E635D23B70123790B8308F8EF /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				5A16F4CFC63FAC439D7A04994F579A03 /* Foundation.framework */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
-		7939F254B0573A96D21B881CD2029C08 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				E3A66D85DB3F80908BACB965E5039416 /* CountryPickerSwift.modulemap */,
-				7E3B6B663AB6FE45D742C22C37FACCE1 /* CountryPickerSwift.xcconfig */,
-				DCBA1A6ED0478E765C7F5FCAF778EF6F /* CountryPickerSwift-dummy.m */,
-				5DA93D91C282ACE37A0836C307F35BFB /* CountryPickerSwift-prefix.pch */,
-				28011D46262278D6737BECDE44643F0B /* CountryPickerSwift-umbrella.h */,
-				514A047EFD69C077B3F0215CACEC531F /* Info.plist */,
-				6B0B4373D8A17E3CF8CCA4A47AD22455 /* ResourceBundle-CountryPicker-Info.plist */,
+				F14AE853B227D6C36EB8B74F7290493F /* CountryPickerSwift.modulemap */,
+				3D4E3A05C19DA3101217F2C7EECB5003 /* CountryPickerSwift.xcconfig */,
+				809AC8DECC19B9758B6ED5684E94C7A3 /* CountryPickerSwift-dummy.m */,
+				4BA7525F315A842F97E1DC39C9E67C65 /* CountryPickerSwift-prefix.pch */,
+				FA2154BC506C6D6BE0A885204DBDAA7C /* CountryPickerSwift-umbrella.h */,
+				6C5555CC500AB7A68F54135A9B6BACE7 /* Info.plist */,
 			);
 			name = "Support Files";
 			path = "Example/Pods/Target Support Files/CountryPickerSwift";
 			sourceTree = "<group>";
 		};
-		7C0B782E81357EEA3BC977143699D919 /* Pod */ = {
+		640940CC6B36A16A49FF36C37822BECF /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				370CFCD40AD7C7F089B48A99A9866301 /* CountryPickerSwift.podspec */,
-				826DCF5F725D40932618C2B19C3119C0 /* LICENSE */,
-				D5EC8D60BA32B3018A381C8202DE0D17 /* README.md */,
+				B5E70251152B2F9EB1628B2AF637D038 /* Assets */,
+				7B8A117432074A597C29BE6F9F142FBD /* Classes */,
 			);
-			name = Pod;
+			name = Resources;
+			sourceTree = "<group>";
+		};
+		7B8A117432074A597C29BE6F9F142FBD /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				9AA84FE8C9AFC29B0FC4647BA492C4F3 /* CountryView.xib */,
+				0445C926242CF429A9C4EAD8D4749729 /* Flags.xcassets */,
+			);
+			name = Classes;
+			path = CountryPicker/Classes;
 			sourceTree = "<group>";
 		};
 		7DB346D0F39D3F0E887471402A8071AB = {
 			isa = PBXGroup;
 			children = (
 				93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */,
-				96EB91B4BCFEE92C725E1B5E096400C0 /* Development Pods */,
+				DD4056E7547A2A9157141BF148A6F95C /* Development Pods */,
 				BC3CA7F9E30CC8F7E2DD044DD34432FC /* Frameworks */,
-				F71E1B93F168D8F1EDC9071892CFDE74 /* Products */,
+				8A64298316AB8CD03199C738F3839F8A /* Products */,
 				7FFDB1D299318C250A622882D1FBED48 /* Targets Support Files */,
 			);
 			sourceTree = "<group>";
@@ -224,18 +183,43 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		96EB91B4BCFEE92C725E1B5E096400C0 /* Development Pods */ = {
+		8A64298316AB8CD03199C738F3839F8A /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				477B19B23BBFF464D0682C4E746B9F4E /* CountryPickerSwift */,
+				13014C828FE6C001D5B4857E213979DF /* CountryPicker.framework */,
+				0BB001A7F239D548C6256ABB43A531F0 /* Pods_CountryPicker_Example.framework */,
+				1DFC453C7245D384D03F0635FFBA1E3D /* Pods_CountryPicker_Tests.framework */,
 			);
-			name = "Development Pods";
+			name = Products;
+			sourceTree = "<group>";
+		};
+		A9915CB6CCA89EE7D56B0A89F77577B1 /* CountryPickerSwift */ = {
+			isa = PBXGroup;
+			children = (
+				67F57299B8A4404FF21CDA426BC0C07B /* CountryPicker.swift */,
+				AEDD87DF6B2E008708DC00FCA76B1575 /* CountryView.swift */,
+				E55F9800B76E6BA34761F6BA26D69DFF /* CountryViewTheme.swift */,
+				D87A80ADD6DA3F6EA62AB9CB2C0D8D63 /* Pod */,
+				640940CC6B36A16A49FF36C37822BECF /* Resources */,
+				541F7E9C90D2A369B4782343F9000FB9 /* Support Files */,
+			);
+			name = CountryPickerSwift;
+			path = ../..;
+			sourceTree = "<group>";
+		};
+		B5E70251152B2F9EB1628B2AF637D038 /* Assets */ = {
+			isa = PBXGroup;
+			children = (
+				7ED665EC6148284D074D91BD2D568507 /* CountryPicker.bundle */,
+			);
+			name = Assets;
+			path = CountryPicker/Assets;
 			sourceTree = "<group>";
 		};
 		BC3CA7F9E30CC8F7E2DD044DD34432FC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				5E0D919E635D23B70123790B8308F8EF /* iOS */,
+				D35AF013A5F0BAD4F32504907A52519E /* iOS */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -258,25 +242,40 @@
 			path = "Target Support Files/Pods-CountryPicker_Tests";
 			sourceTree = "<group>";
 		};
-		F71E1B93F168D8F1EDC9071892CFDE74 /* Products */ = {
+		D35AF013A5F0BAD4F32504907A52519E /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				293B35B9C2FFAEF6FAB48F03110BEC40 /* CountryPicker.bundle */,
-				291482A4DA68041C2FBC8288A895D7E2 /* CountryPicker.framework */,
-				1BA4A49C63967AD6B861C29F09758C1B /* Pods_CountryPicker_Example.framework */,
-				70240CDDF836F7AC9DB70DB5BA30F85A /* Pods_CountryPicker_Tests.framework */,
+				6604A7D69453B4569E4E4827FB9155A9 /* Foundation.framework */,
 			);
-			name = Products;
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		D87A80ADD6DA3F6EA62AB9CB2C0D8D63 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				36809505866F9F83FB9FFE2284EA89A9 /* CountryPickerSwift.podspec */,
+				C54CBAE888CEC4F59EF391CFABF093FB /* LICENSE */,
+				54348BC98699843A76E5FCCC9916E2D1 /* README.md */,
+			);
+			name = Pod;
+			sourceTree = "<group>";
+		};
+		DD4056E7547A2A9157141BF148A6F95C /* Development Pods */ = {
+			isa = PBXGroup;
+			children = (
+				A9915CB6CCA89EE7D56B0A89F77577B1 /* CountryPickerSwift */,
+			);
+			name = "Development Pods";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		7206643B46D9A5C71C509F46AC965541 /* Headers */ = {
+		A8FA791571730D83F0DC6D4AF2522FD0 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EF9514F76AE749515D36F6FE4AAA1F48 /* CountryPickerSwift-umbrella.h in Headers */,
+				86F0BCCFA7F2BB948998BCAF121D1DCF /* CountryPickerSwift-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -299,42 +298,6 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		15AF30C8115A773B14C33A1C97C018E5 /* CountryPickerSwift */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = D11B7E4960192FEDCDE4784C29C10D11 /* Build configuration list for PBXNativeTarget "CountryPickerSwift" */;
-			buildPhases = (
-				CC5E188439746C0B2773C0732067AA71 /* Sources */,
-				A413592AE2F85D9CA4B7FEA2000591EE /* Frameworks */,
-				77CC8EC89BF7E71494429F5C457B8EE9 /* Resources */,
-				7206643B46D9A5C71C509F46AC965541 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				8DDFA5CD115AA9E0A66B13B33EB183D8 /* PBXTargetDependency */,
-			);
-			name = CountryPickerSwift;
-			productName = CountryPickerSwift;
-			productReference = 291482A4DA68041C2FBC8288A895D7E2 /* CountryPicker.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		1D60595B83998629E5BF7286F76298D0 /* CountryPickerSwift-CountryPicker */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 470566221B70ED75897AB4F4BBD8C0D3 /* Build configuration list for PBXNativeTarget "CountryPickerSwift-CountryPicker" */;
-			buildPhases = (
-				AB22D090763BA03363DAD58331F5ECFE /* Sources */,
-				2D0A5AD998F86F35D22EC640C5DA0852 /* Frameworks */,
-				962E0AFE687C9ADEA5A74B97FD7BE8C8 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "CountryPickerSwift-CountryPicker";
-			productName = "CountryPickerSwift-CountryPicker";
-			productReference = 293B35B9C2FFAEF6FAB48F03110BEC40 /* CountryPicker.bundle */;
-			productType = "com.apple.product-type.bundle";
-		};
 		3ED74298185CE2A6AB9074E6815A9A38 /* Pods-CountryPicker_Example */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 471E4A2703D9A0558DA4DD8F8A82B37A /* Build configuration list for PBXNativeTarget "Pods-CountryPicker_Example" */;
@@ -350,7 +313,7 @@
 			);
 			name = "Pods-CountryPicker_Example";
 			productName = "Pods-CountryPicker_Example";
-			productReference = 1BA4A49C63967AD6B861C29F09758C1B /* Pods_CountryPicker_Example.framework */;
+			productReference = 0BB001A7F239D548C6256ABB43A531F0 /* Pods_CountryPicker_Example.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		BCA91EE66313A524B65FCC5B6F66047A /* Pods-CountryPicker_Tests */ = {
@@ -368,7 +331,25 @@
 			);
 			name = "Pods-CountryPicker_Tests";
 			productName = "Pods-CountryPicker_Tests";
-			productReference = 70240CDDF836F7AC9DB70DB5BA30F85A /* Pods_CountryPicker_Tests.framework */;
+			productReference = 1DFC453C7245D384D03F0635FFBA1E3D /* Pods_CountryPicker_Tests.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		F4B55C5FBC8AD531B30BE59C71695A0D /* CountryPickerSwift */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5ADD21A2C343290DDC50ADF597304C45 /* Build configuration list for PBXNativeTarget "CountryPickerSwift" */;
+			buildPhases = (
+				654B1A8DF9C19CB7B84104FE04C975AD /* Sources */,
+				7D05270AFC7099DCCF83AB45485844A4 /* Frameworks */,
+				2D45D99E554F04971229E84BE2147D76 /* Resources */,
+				A8FA791571730D83F0DC6D4AF2522FD0 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CountryPickerSwift;
+			productName = CountryPickerSwift;
+			productReference = 13014C828FE6C001D5B4857E213979DF /* CountryPicker.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -388,12 +369,11 @@
 				en,
 			);
 			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
-			productRefGroup = F71E1B93F168D8F1EDC9071892CFDE74 /* Products */;
+			productRefGroup = 8A64298316AB8CD03199C738F3839F8A /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				15AF30C8115A773B14C33A1C97C018E5 /* CountryPickerSwift */,
-				1D60595B83998629E5BF7286F76298D0 /* CountryPickerSwift-CountryPicker */,
+				F4B55C5FBC8AD531B30BE59C71695A0D /* CountryPickerSwift */,
 				3ED74298185CE2A6AB9074E6815A9A38 /* Pods-CountryPicker_Example */,
 				BCA91EE66313A524B65FCC5B6F66047A /* Pods-CountryPicker_Tests */,
 			);
@@ -401,20 +381,13 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		77CC8EC89BF7E71494429F5C457B8EE9 /* Resources */ = {
+		2D45D99E554F04971229E84BE2147D76 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C033B8CB562EFBDCF5C566483FD58212 /* CountryPicker.bundle in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		962E0AFE687C9ADEA5A74B97FD7BE8C8 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				4119FC15F9A7CFBCB5CEC272FED85BB3 /* Data in Resources */,
-				F7F24D365351F0ADBA12D4DE1A46D986 /* Images in Resources */,
+				BEC0FC600B709FDBAA3D5EC5EF62C71A /* CountryPicker.bundle in Resources */,
+				4BBD98A04F28E972987EAFCCDC42623F /* CountryView.xib in Resources */,
+				35D0A2B7618A6A68403F0DD75274DA7A /* Flags.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -429,10 +402,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		AB22D090763BA03363DAD58331F5ECFE /* Sources */ = {
+		654B1A8DF9C19CB7B84104FE04C975AD /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78FA7604C2CC8B0E7F0ABD6162DCC0E5 /* CountryPicker.swift in Sources */,
+				1B9190EFB9A49D21D50B00BA7295D8EC /* CountryPickerSwift-dummy.m in Sources */,
+				BA9BB2689D1F7EFB53EF442AFC4B82E8 /* CountryView.swift in Sources */,
+				F67EDB02D7738D3E92CDEDAC743F1DD3 /* CountryViewTheme.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -444,32 +421,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CC5E188439746C0B2773C0732067AA71 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				50678BF1924742865714B066346FB28E /* CountryPicker.swift in Sources */,
-				C52629C606D3851B56831DC762B2C4BC /* CountryPickerSwift-dummy.m in Sources */,
-				4479F083EF7BAA3900A6B4FDB44FF898 /* CountryView.swift in Sources */,
-				1ECFB95D5027B0E84048DDCA1C8560C4 /* CountryView.xib in Sources */,
-				11D530460099E05EBB52E562C58FF4BF /* CountryViewTheme.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
 		7D0AAD75855CAE3BC8995BD413901A84 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = CountryPickerSwift;
-			target = 15AF30C8115A773B14C33A1C97C018E5 /* CountryPickerSwift */;
+			target = F4B55C5FBC8AD531B30BE59C71695A0D /* CountryPickerSwift */;
 			targetProxy = 50B5B99D8145A29206E409E117C4D150 /* PBXContainerItemProxy */;
-		};
-		8DDFA5CD115AA9E0A66B13B33EB183D8 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "CountryPickerSwift-CountryPicker";
-			target = 1D60595B83998629E5BF7286F76298D0 /* CountryPickerSwift-CountryPicker */;
-			targetProxy = C867ABF451C723BFC1EC672CB703CD92 /* PBXContainerItemProxy */;
 		};
 		E567A3662D13C09959248F4AA9C91898 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -480,39 +439,6 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		053C76CB5197C4DE96F5C31DB452880B /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7E3B6B663AB6FE45D742C22C37FACCE1 /* CountryPickerSwift.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/CountryPickerSwift/CountryPickerSwift-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/CountryPickerSwift/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/CountryPickerSwift/CountryPickerSwift.modulemap";
-				PRODUCT_MODULE_NAME = CountryPicker;
-				PRODUCT_NAME = CountryPicker;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
 		199D972A13F2B4C56847F7A89CCA83BC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -576,54 +502,6 @@
 			};
 			name = Debug;
 		};
-		2B80611AD0C7E7F6AACCD2689D92BBEC /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7E3B6B663AB6FE45D742C22C37FACCE1 /* CountryPickerSwift.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/CountryPickerSwift/CountryPickerSwift-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/CountryPickerSwift/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/CountryPickerSwift/CountryPickerSwift.modulemap";
-				PRODUCT_MODULE_NAME = CountryPicker;
-				PRODUCT_NAME = CountryPicker;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		2D094C1D04327F2D73C8BEABA15A4E2A /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7E3B6B663AB6FE45D742C22C37FACCE1 /* CountryPickerSwift.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/CountryPickerSwift";
-				INFOPLIST_FILE = "Target Support Files/CountryPickerSwift/ResourceBundle-CountryPicker-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				PRODUCT_NAME = CountryPicker;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				WRAPPER_EXTENSION = bundle;
-			};
-			name = Debug;
-		};
 		41E5C5C0EE8C6FD2F11D994DF3C7C77D /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1B22A0C25E3D6C54656096673881FF24 /* Pods-CountryPicker_Example.release.xcconfig */;
@@ -659,21 +537,37 @@
 			};
 			name = Release;
 		};
-		7B0C3E14106F3BE5C69B5F2694AF82C3 /* Release */ = {
+		6A283C01A3539D169458395C8C656676 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7E3B6B663AB6FE45D742C22C37FACCE1 /* CountryPickerSwift.xcconfig */;
+			baseConfigurationReference = 3D4E3A05C19DA3101217F2C7EECB5003 /* CountryPickerSwift.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/CountryPickerSwift";
-				INFOPLIST_FILE = "Target Support Files/CountryPickerSwift/ResourceBundle-CountryPicker-Info.plist";
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/CountryPickerSwift/CountryPickerSwift-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/CountryPickerSwift/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/CountryPickerSwift/CountryPickerSwift.modulemap";
+				PRODUCT_MODULE_NAME = CountryPicker;
 				PRODUCT_NAME = CountryPicker;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WRAPPER_EXTENSION = bundle;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
 			};
-			name = Release;
+			name = Debug;
 		};
 		89B8EF886559175032006721691A1A6D /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -707,6 +601,39 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
+		};
+		C378AE38770A293DDDC8ACBF220DA183 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3D4E3A05C19DA3101217F2C7EECB5003 /* CountryPickerSwift.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/CountryPickerSwift/CountryPickerSwift-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/CountryPickerSwift/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/CountryPickerSwift/CountryPickerSwift.modulemap";
+				PRODUCT_MODULE_NAME = CountryPicker;
+				PRODUCT_NAME = CountryPicker;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
 		};
 		C7C6C0E75D8021052DBF40B831065723 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -856,15 +783,6 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		470566221B70ED75897AB4F4BBD8C0D3 /* Build configuration list for PBXNativeTarget "CountryPickerSwift-CountryPicker" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				2D094C1D04327F2D73C8BEABA15A4E2A /* Debug */,
-				7B0C3E14106F3BE5C69B5F2694AF82C3 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		471E4A2703D9A0558DA4DD8F8A82B37A /* Build configuration list for PBXNativeTarget "Pods-CountryPicker_Example" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -874,11 +792,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		D11B7E4960192FEDCDE4784C29C10D11 /* Build configuration list for PBXNativeTarget "CountryPickerSwift" */ = {
+		5ADD21A2C343290DDC50ADF597304C45 /* Build configuration list for PBXNativeTarget "CountryPickerSwift" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				2B80611AD0C7E7F6AACCD2689D92BBEC /* Debug */,
-				053C76CB5197C4DE96F5C31DB452880B /* Release */,
+				6A283C01A3539D169458395C8C656676 /* Debug */,
+				C378AE38770A293DDDC8ACBF220DA183 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
Hello,

This provide a modification to the podspec. Using `s.ressources` avoids the crash and the modification of the code base to fit with the new bundle created :) 

[Related Issue](https://github.com/4taras4/CountryCode/issues/41)