### PR TITLE
#Improving performance for fast visibility of UI

### DIFF
--- a/CountryPicker/Classes/CountryPicker.swift
+++ b/CountryPicker/Classes/CountryPicker.swift
@@ -297,7 +297,7 @@ private extension CountryPicker {
         }
         if let display = exeptCountriesWithCodes {
             // Filtering `display codes` from local storage
-            let filteredCodes = Set(allCountriesCode).intersection(display)
+            let filteredCodes = Set(allCountriesCode).subtracting(display)
             // Filtering countries
             updateCountryList(with: filteredCodes)
         }


### PR DESCRIPTION
**Issue**

When providing `displayOnlyCountriesWithCodes` with a large list, UI is taking almost around 3 seconds to display.

**Overview**

When providing a large list of `displayOnlyCountriesWithCodes` to CountryPicker, it is taking huge time to display itself

**Root Cause**

On digging deeper, I found that the issue in a way how we are accessing `countries` variable. On every access, we are performing 2 major time consuming operations which are listed below:
- Taking list of countries from local JSON and performing serializing objects using `JSONSerialization`
- Iterating and filtering through list in N x M time where n = size of our local list and m = size of countries list to display

**Solution**
- Fetch locally stored countries on initialization and store it in local variable so that we do not have to perform `JSONSerialization` repeatedly
- Use `Sets` for performing filtering operation