### PR TITLE
Fix SPM support and request to tag 1.8.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "CountryCode",
+    platforms: [
+        .iOS(.v8)
+    ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
@@ -21,7 +24,10 @@ let package = Package(
         .target(
             name: "CountryCode",
             dependencies: [],
-            path: "CountryPicker"),
+            path: "CountryPicker",
+            resources: [
+                .copy("Assets")]
+        ),
         .testTarget(
             name: "CountryCodeTests",
             dependencies: ["CountryCode"]),


### PR DESCRIPTION
* Fix SPM support to explicitly include `CountryPicker.bundle` as a resource, otherwise `countryCodes.json` may not be included.  Because of the `guard let` on line 188 of `CountryPicker.swift`, failure to load the JSON silently fails and returns an empty `Set`.
* Add conditionals to use `Bundle.module` when compiled with SPM.
* Update Podspec for 1.8.3 and regenerate lockfiles.  I would request that this be tagged as 1.8.3 at the same time, so that SPM will see the recent SPM-specific commits for that version, instead of having to just follow `master`.