### PR TITLE
Fix SPM support and request to tag 1.8.3: fix for #63

### DIFF
--- a/CountryPicker/Classes/CountryPicker.swift
+++ b/CountryPicker/Classes/CountryPicker.swift
@@ -44,7 +44,12 @@ public struct Country {
     }
     
     public var flag: UIImage? {
-        return UIImage(named: flagName, in: Bundle(for: CountryPicker.self), compatibleWith: nil)
+        #if SWIFT_PACKAGE
+        let bundle = Bundle.module
+        #else
+        let bundle = Bundle(for: CountryPicker.self)
+        #endif
+        return UIImage(named: flagName, in: bundle, compatibleWith: nil)
     }
 }
 

--- a/CountryPicker/Classes/CountryView.swift
+++ b/CountryPicker/Classes/CountryView.swift
@@ -43,7 +43,11 @@ class NibLoadingView: UIView {
     ///
     /// - Returns: XIBView
     fileprivate func loadViewFromNib() -> UIView {
+        #if SWIFT_PACKAGE
+        let bundle = Bundle.module
+        #else
         let bundle = Bundle(for: type(of: self))
+        #endif
         let nib = UINib(nibName: String(describing: type(of: self)), bundle: bundle)
         let nibView = nib.instantiate(withOwner: self, options: nil).first as! UIView
         

--- a/CountryPickerSwift.podspec
+++ b/CountryPickerSwift.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'CountryPickerSwift'
-  s.version          = '1.8.2'
+  s.version          = '1.8.3'
   s.summary          = 'Swift CountryPicker'
 
 # This description is used to generate tags and improve search results.

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - CountryPickerSwift (1.8.2)
+  - CountryPickerSwift (1.8.3)
 
 DEPENDENCIES:
   - CountryPickerSwift (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  CountryPickerSwift: f969cd261fc03978c0a556c4863b1047188bb4ca
+  CountryPickerSwift: 70dcf23b7f28895eb97d7e461a661524126b349a
 
 PODFILE CHECKSUM: 24f5b92c2a79e38c578da696a7b6140d7772a81d
 

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - CountryPickerSwift (1.8.2)
+  - CountryPickerSwift (1.8.3)
 
 DEPENDENCIES:
   - CountryPickerSwift (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  CountryPickerSwift: f969cd261fc03978c0a556c4863b1047188bb4ca
+  CountryPickerSwift: 70dcf23b7f28895eb97d7e461a661524126b349a
 
 PODFILE CHECKSUM: 24f5b92c2a79e38c578da696a7b6140d7772a81d
 

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
             dependencies: [],
             path: "CountryPicker",
             resources: [
-                .copy("Assets")]
+                .copy("Assets/CountryPicker.bundle")]
         ),
         .testTarget(
             name: "CountryCodeTests",


### PR DESCRIPTION
My error, #63 only contains some of the work I intended to add to that PR.  This branch is the full thing, if you could merge and re-tag 1.8.3.  The change list is the same.

* Fix SPM support to explicitly include `CountryPicker.bundle` as a resource, otherwise `countryCodes.json` may not be included.  Because of the `guard let` on line 188 of `CountryPicker.swift`, failure to load the JSON silently fails and returns an empty `Set`.
* Add conditionals to use `Bundle.module` when compiled with SPM.
* Update Podspec for 1.8.3 and regenerate lockfiles.  I would request that this be tagged as 1.8.3 at the same time, so that SPM will see the recent SPM-specific commits for that version, instead of having to just follow `master`.